### PR TITLE
Add Grok key input and collapse tweets

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -3,7 +3,12 @@ chrome.runtime.onMessage.addListener(async (msg, sender) => {
   if (!msg.grokPrompt) return;
 
   const API_URL  = 'https://api.x.ai/v1/chat/completions';
-  const GROK_KEY = 'xai-chvcMDSdXqc7ozUQreHKLqnA3EBvDidq7ReIZFMRCspVcDnNpOeDveXyFjFBRuftp6mw1lyiIE5u9d8J';
+  const { grokKey } = await chrome.storage.local.get('grokKey');
+  if (!grokKey) {
+    console.error('Grok API key not set.');
+    return;
+  }
+  const GROK_KEY = grokKey;
 
   let summary = 'No';
   try {

--- a/popup.html
+++ b/popup.html
@@ -10,6 +10,7 @@
   </head>
   <body>
     <input id="filter" type="text" placeholder="Enter filter phrase…" />
+    <input id="grokKey" type="password" placeholder="Enter Grok API key…" />
     <button id="go">Check Tweets</button>
     <div id="status"></div>
     <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -1,20 +1,22 @@
 // popup.js
-const btn    = document.getElementById('go');
-const input  = document.getElementById('filter');
-const status = document.getElementById('status');
+const btn      = document.getElementById('go');
+const input    = document.getElementById('filter');
+const keyInput = document.getElementById('grokKey');
+const status   = document.getElementById('status');
 
 btn.addEventListener('click', async () => {
   const filter = input.value.trim();
-  if (!filter) {
-    status.textContent = 'Please enter a filter phrase.';
+  const grokKey = keyInput.value.trim();
+  if (!filter || !grokKey) {
+    status.textContent = 'Please enter both a filter phrase and API key.';
     return;
   }
 
   btn.disabled    = true;
   status.textContent = 'Running…';
 
-  // store filter for scraper.js
-  await chrome.storage.local.set({ filter });
+  // store filter and API key for scripts
+  await chrome.storage.local.set({ filter, grokKey });
 
   // inject scraper into the current tab
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });

--- a/scraper.js
+++ b/scraper.js
@@ -10,11 +10,7 @@
     return;
   }
 
-  // 2) Grok API info
-  const GROK_KEY = '';
-  const API_URL  = 'https://api.x.ai/v1/chat/completions';
-
-  // 3) walk each tweet cell
+  // walk each tweet cell
   const cells = [...document.querySelectorAll('[data-testid="cellInnerDiv"]')];
   for (const cell of cells) {
     // stop at “Discover more”
@@ -56,9 +52,10 @@ Tweet:
       });
     });
 
-    // if it’s a “No”, highlight in red
+    // if it’s a “No”, collapse the tweet
     if (/^no$/i.test(verdict)) {
-      textNode.style.color = 'red';
+      cell.style.height   = '0px';
+      cell.style.overflow = 'hidden';
     }
   }
 


### PR DESCRIPTION
## Summary
- allow entering Grok API key in popup
- store key for background fetch
- pull key from storage in `bg.js`
- collapse tweets instead of coloring text

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c4afdd9848333bb6a98147aafdcc8