### PR TITLE
Add toggle for tweet checking and skip processed tweets

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -4,33 +4,43 @@ const input    = document.getElementById('filter');
 const keyInput = document.getElementById('grokKey');
 const status   = document.getElementById('status');
 
+async function updateUI() {
+  const { checking, filter, grokKey } = await chrome.storage.local.get([
+    'checking',
+    'filter',
+    'grokKey'
+  ]);
+  input.value = filter || '';
+  keyInput.value = grokKey || '';
+  btn.textContent = checking ? 'Stop Checking' : 'Check Tweets';
+  status.textContent = checking ? 'Checking tweets…' : '';
+}
+
+updateUI();
+
 btn.addEventListener('click', async () => {
-  const filter = input.value.trim();
-  const grokKey = keyInput.value.trim();
-  if (!filter || !grokKey) {
-    status.textContent = 'Please enter both a filter phrase and API key.';
-    return;
+  let { checking } = await chrome.storage.local.get('checking');
+  checking = !checking;
+
+  if (checking) {
+    const filter = input.value.trim();
+    const grokKey = keyInput.value.trim();
+    if (!filter || !grokKey) {
+      status.textContent = 'Please enter both a filter phrase and API key.';
+      return;
+    }
+    await chrome.storage.local.set({ filter, grokKey, checking: true });
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files: ['scraper.js']
+    });
+    status.textContent = 'Checking tweets…';
+  } else {
+    await chrome.storage.local.set({ checking: false });
+    status.textContent = 'Paused.';
   }
 
-  btn.disabled    = true;
-  status.textContent = 'Running…';
-
-  // store filter and API key for scripts
-  await chrome.storage.local.set({ filter, grokKey });
-
-  // inject scraper into the current tab
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  await chrome.scripting.executeScript({
-    target: { tabId: tab.id },
-    files: ['scraper.js']
-  });
-
-  // wait for done ping
-  chrome.runtime.onMessage.addListener(function listener(msg, sender) {
-    if (msg.done && sender.tab.id === tab.id) {
-      status.textContent = 'Finished.';
-      btn.disabled      = false;
-      chrome.runtime.onMessage.removeListener(listener);
-    }
-  });
+  btn.textContent = checking ? 'Stop Checking' : 'Check Tweets';
 });
+


### PR DESCRIPTION
## Summary
- implement toggle functionality in the popup to start/stop tweet checking
- store the state and update UI based on whether checking is active
- update scraper to watch the page and skip tweets that were already processed

## Testing
- `node --check popup.js`
- `node --check scraper.js`


------
https://chatgpt.com/codex/tasks/task_e_684c4e252ed88333bd36ba6113a10066