### PR TITLE
Hide ads in tweet filter

### DIFF
--- a/scraper.js
+++ b/scraper.js
@@ -21,11 +21,14 @@
       stop();
       return;
     }
-    // skip ads
+    // hide ads
     if ([...cell.querySelectorAll('span.css-1jxf684')]
           .some(s => s.textContent.trim() === 'Ad')) {
+      cell.style.height   = '0px';
+      cell.style.overflow = 'hidden';
       return;
     }
+    if (!filter || !grokKey) return;
 
     const textNode = cell.querySelector('[data-testid="tweetText"]');
     if (!textNode) return;
@@ -60,7 +63,6 @@ Tweet:
 
   async function scan() {
     await loadConfig();
-    if (!filter || !grokKey) return;
     const cells = [...document.querySelectorAll('[data-testid="cellInnerDiv"]')];
     for (const c of cells) {
       await processCell(c);


### PR DESCRIPTION
## Summary
- hide tweets marked as ads
- always scan for ads regardless of configured filters

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c4f27433883339472032055d693f7