### PR TITLE
Update popup with tabs and toggles

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -3,7 +3,8 @@ chrome.runtime.onMessage.addListener(async (msg, sender) => {
   if (!msg.grokPrompt) return;
 
   const API_URL  = 'https://api.x.ai/v1/chat/completions';
-  const { grokKey } = await chrome.storage.local.get('grokKey');
+  const { grokKey, models } = await chrome.storage.local.get(['grokKey', 'models']);
+  if (!models?.includes('grok')) return;
   if (!grokKey) {
     console.error('Grok API key not set.');
     return;

--- a/popup.html
+++ b/popup.html
@@ -6,12 +6,36 @@
       body    { font-family: sans-serif; padding: 12px; width: 220px; }
       input, button { width: 100%; margin-top: 6px; padding: 6px; font-size: 14px; }
       #status { margin-top: 8px; font-size: 12px; color: #555; }
+      .tabs { display: flex; margin-bottom: 6px; }
+      .tab-btn { flex: 1; padding: 6px; text-align: center; background: #eee; border: 1px solid #ccc; cursor: pointer; }
+      .tab-btn.active { background: #fff; }
+      .tab { display: none; }
+      .tab.active { display: block; }
+      .models { display: flex; justify-content: space-between; margin-top: 6px; }
+      .models label { flex: 1; font-size: 12px; }
     </style>
   </head>
   <body>
-    <input id="filter" type="text" placeholder="Enter filter phrase…" />
-    <input id="grokKey" type="password" placeholder="Enter Grok API key…" />
-    <button id="go">Check Tweets</button>
+    <div class="tabs">
+      <div id="filteringTabBtn" class="tab-btn active">Filtering</div>
+      <div id="adBlockTabBtn" class="tab-btn">Ad Blocking</div>
+    </div>
+
+    <div id="filteringTab" class="tab active">
+      <input id="filter" type="text" placeholder="Enter filter phrase…" />
+      <input id="grokKey" type="password" placeholder="Enter Grok API key…" />
+      <div class="models">
+        <label><input type="checkbox" id="modelClaude"> Claude</label>
+        <label><input type="checkbox" id="modelGpt"> GPT</label>
+        <label><input type="checkbox" id="modelGrok"> Grok</label>
+      </div>
+      <button id="go">Check Tweets</button>
+    </div>
+
+    <div id="adBlockTab" class="tab">
+      <button id="toggleAds">Ad Filtering: Off</button>
+    </div>
+
     <div id="status"></div>
     <script src="popup.js"></script>
   </body>

--- a/popup.js
+++ b/popup.js
@@ -1,19 +1,74 @@
 // popup.js
-const btn      = document.getElementById('go');
-const input    = document.getElementById('filter');
-const keyInput = document.getElementById('grokKey');
-const status   = document.getElementById('status');
+const btn        = document.getElementById('go');
+const input      = document.getElementById('filter');
+const keyInput   = document.getElementById('grokKey');
+const status     = document.getElementById('status');
+const filteringTabBtn = document.getElementById('filteringTabBtn');
+const adBlockTabBtn   = document.getElementById('adBlockTabBtn');
+const filteringTab    = document.getElementById('filteringTab');
+const adBlockTab      = document.getElementById('adBlockTab');
+const toggleAdsBtn    = document.getElementById('toggleAds');
+const modelClaude     = document.getElementById('modelClaude');
+const modelGpt        = document.getElementById('modelGpt');
+const modelGrok       = document.getElementById('modelGrok');
+
+function showTab(which) {
+  filteringTab.classList.remove('active');
+  adBlockTab.classList.remove('active');
+  filteringTabBtn.classList.remove('active');
+  adBlockTabBtn.classList.remove('active');
+  if (which === 'ad') {
+    adBlockTab.classList.add('active');
+    adBlockTabBtn.classList.add('active');
+  } else {
+    filteringTab.classList.add('active');
+    filteringTabBtn.classList.add('active');
+  }
+}
+
+filteringTabBtn.addEventListener('click', () => showTab('filter'));
+adBlockTabBtn.addEventListener('click', () => showTab('ad'));
+
+function getSelectedModels() {
+  const models = [];
+  if (modelClaude.checked) models.push('claude');
+  if (modelGpt.checked)    models.push('gpt');
+  if (modelGrok.checked)   models.push('grok');
+  return models;
+}
+
+function saveModels() {
+  chrome.storage.local.set({ models: getSelectedModels() });
+}
+
+modelClaude.addEventListener('change', saveModels);
+modelGpt.addEventListener('change', saveModels);
+modelGrok.addEventListener('change', saveModels);
+
+toggleAdsBtn.addEventListener('click', async () => {
+  let { filterAds } = await chrome.storage.local.get('filterAds');
+  filterAds = !filterAds;
+  await chrome.storage.local.set({ filterAds });
+  toggleAdsBtn.textContent = filterAds ? 'Ad Filtering: On' : 'Ad Filtering: Off';
+});
 
 async function updateUI() {
-  const { checking, filter, grokKey } = await chrome.storage.local.get([
+  const { checking, filter, grokKey, filterAds, models } = await chrome.storage.local.get([
     'checking',
     'filter',
-    'grokKey'
+    'grokKey',
+    'filterAds',
+    'models'
   ]);
   input.value = filter || '';
   keyInput.value = grokKey || '';
   btn.textContent = checking ? 'Stop Checking' : 'Check Tweets';
   status.textContent = checking ? 'Checking tweets…' : '';
+  toggleAdsBtn.textContent = filterAds ? 'Ad Filtering: On' : 'Ad Filtering: Off';
+  const m = new Set(models || []);
+  modelClaude.checked = m.has('claude');
+  modelGpt.checked    = m.has('gpt');
+  modelGrok.checked   = m.has('grok');
 }
 
 updateUI();
@@ -29,7 +84,8 @@ btn.addEventListener('click', async () => {
       status.textContent = 'Please enter both a filter phrase and API key.';
       return;
     }
-    await chrome.storage.local.set({ filter, grokKey, checking: true });
+    const models = getSelectedModels();
+    await chrome.storage.local.set({ filter, grokKey, checking: true, models });
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
     await chrome.scripting.executeScript({
       target: { tabId: tab.id },
@@ -43,4 +99,3 @@ btn.addEventListener('click', async () => {
 
   btn.textContent = checking ? 'Stop Checking' : 'Check Tweets';
 });
-

--- a/scraper.js
+++ b/scraper.js
@@ -4,11 +4,15 @@
   let observer;
   let filter = '';
   let grokKey = '';
+  let filterAds = true;
+  let models = ['grok'];
 
   async function loadConfig() {
-    const cfg = await chrome.storage.local.get(['filter', 'grokKey']);
+    const cfg = await chrome.storage.local.get(['filter', 'grokKey', 'filterAds', 'models']);
     filter = cfg.filter || '';
     grokKey = cfg.grokKey || '';
+    filterAds = cfg.filterAds !== false;
+    models = cfg.models || ['grok'];
   }
 
   async function processCell(cell) {
@@ -22,13 +26,13 @@
       return;
     }
     // hide ads
-    if ([...cell.querySelectorAll('span.css-1jxf684')]
+    if (filterAds && [...cell.querySelectorAll('span.css-1jxf684')]
           .some(s => s.textContent.trim() === 'Ad')) {
       cell.style.height   = '0px';
       cell.style.overflow = 'hidden';
       return;
     }
-    if (!filter || !grokKey) return;
+    if (!filter || !grokKey || !models.includes('grok')) return;
 
     const textNode = cell.querySelector('[data-testid="tweetText"]');
     if (!textNode) return;
@@ -88,7 +92,7 @@ Tweet:
       if ('checking' in changes) {
         changes.checking.newValue ? start() : stop();
       }
-      if ('filter' in changes || 'grokKey' in changes) {
+      if ('filter' in changes || 'grokKey' in changes || 'filterAds' in changes || 'models' in changes) {
         loadConfig();
       }
     }


### PR DESCRIPTION
## Summary
- add Filtering and Ad Blocking tabs in the popup
- add checkboxes to select Claude, GPT or Grok for filtering
- allow toggling ad filtering on/off
- adjust scripts to respect the new ad filtering toggle and selected models

## Testing
- `node --check popup.js`
- `node --check scraper.js`
- `node --check bg.js`


------
https://chatgpt.com/codex/tasks/task_e_684c7426164883338fc2b6e203e6c51e