### PR TITLE
Add highlight option for filtered tweets

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -29,6 +29,10 @@
         <label><input type="checkbox" id="modelGpt"> GPT</label>
         <label><input type="checkbox" id="modelGrok"> Grok</label>
       </div>
+      <select id="filterMode">
+        <option value="hide">Hide Tweets</option>
+        <option value="highlight">Highlight Tweets</option>
+      </select>
       <button id="go">Check Tweets</button>
     </div>
 

--- a/popup.js
+++ b/popup.js
@@ -11,6 +11,7 @@ const toggleAdsBtn    = document.getElementById('toggleAds');
 const modelClaude     = document.getElementById('modelClaude');
 const modelGpt        = document.getElementById('modelGpt');
 const modelGrok       = document.getElementById('modelGrok');
+const filterModeSel   = document.getElementById('filterMode');
 
 function showTab(which) {
   filteringTab.classList.remove('active');
@@ -44,6 +45,9 @@ function saveModels() {
 modelClaude.addEventListener('change', saveModels);
 modelGpt.addEventListener('change', saveModels);
 modelGrok.addEventListener('change', saveModels);
+filterModeSel.addEventListener('change', () => {
+  chrome.storage.local.set({ filterMode: filterModeSel.value });
+});
 
 toggleAdsBtn.addEventListener('click', async () => {
   let { filterAds } = await chrome.storage.local.get('filterAds');
@@ -53,12 +57,13 @@ toggleAdsBtn.addEventListener('click', async () => {
 });
 
 async function updateUI() {
-  const { checking, filter, grokKey, filterAds, models } = await chrome.storage.local.get([
+  const { checking, filter, grokKey, filterAds, models, filterMode } = await chrome.storage.local.get([
     'checking',
     'filter',
     'grokKey',
     'filterAds',
-    'models'
+    'models',
+    'filterMode'
   ]);
   input.value = filter || '';
   keyInput.value = grokKey || '';
@@ -69,6 +74,7 @@ async function updateUI() {
   modelClaude.checked = m.has('claude');
   modelGpt.checked    = m.has('gpt');
   modelGrok.checked   = m.has('grok');
+  filterModeSel.value = filterMode || 'hide';
 }
 
 updateUI();
@@ -85,7 +91,13 @@ btn.addEventListener('click', async () => {
       return;
     }
     const models = getSelectedModels();
-    await chrome.storage.local.set({ filter, grokKey, checking: true, models });
+    await chrome.storage.local.set({
+      filter,
+      grokKey,
+      checking: true,
+      models,
+      filterMode: filterModeSel.value
+    });
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
     await chrome.scripting.executeScript({
       target: { tabId: tab.id },

--- a/scraper.js
+++ b/scraper.js
@@ -6,13 +6,21 @@
   let grokKey = '';
   let filterAds = true;
   let models = ['grok'];
+  let filterMode = 'hide';
 
   async function loadConfig() {
-    const cfg = await chrome.storage.local.get(['filter', 'grokKey', 'filterAds', 'models']);
+    const cfg = await chrome.storage.local.get([
+      'filter',
+      'grokKey',
+      'filterAds',
+      'models',
+      'filterMode'
+    ]);
     filter = cfg.filter || '';
     grokKey = cfg.grokKey || '';
     filterAds = cfg.filterAds !== false;
     models = cfg.models || ['grok'];
+    filterMode = cfg.filterMode || 'hide';
   }
 
   async function processCell(cell) {
@@ -60,8 +68,13 @@ Tweet:
     });
 
     if (/^no$/i.test(verdict)) {
-      cell.style.height   = '0px';
-      cell.style.overflow = 'hidden';
+      if (filterMode === 'highlight') {
+        cell.style.backgroundColor = '#fff3cd';
+        cell.style.opacity = '0.6';
+      } else {
+        cell.style.height   = '0px';
+        cell.style.overflow = 'hidden';
+      }
     }
   }
 
@@ -92,7 +105,11 @@ Tweet:
       if ('checking' in changes) {
         changes.checking.newValue ? start() : stop();
       }
-      if ('filter' in changes || 'grokKey' in changes || 'filterAds' in changes || 'models' in changes) {
+      if ('filter' in changes ||
+          'grokKey' in changes ||
+          'filterAds' in changes ||
+          'models' in changes ||
+          'filterMode' in changes) {
         loadConfig();
       }
     }


### PR DESCRIPTION
## Summary
- allow choosing between hiding or highlighting filtered tweets
- store user's highlight preference in extension storage
- reload config when highlight setting changes

## Testing
- `node --check popup.js`
- `node --check scraper.js`
- `node --check bg.js`

------
https://chatgpt.com/codex/tasks/task_e_684c99f0d3cc8333954ec071d6242a47