### PR TITLE
Add GPT and Claude support

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -1,45 +1,96 @@
 // bg.js
 chrome.runtime.onMessage.addListener(async (msg, sender) => {
-  if (!msg.grokPrompt) return;
+  if (!msg.prompt) return;
 
-  const API_URL  = 'https://api.x.ai/v1/chat/completions';
-  const { grokKey, models } = await chrome.storage.local.get(['grokKey', 'models']);
-  if (!models?.includes('grok')) return;
-  if (!grokKey) {
-    console.error('Grok API key not set.');
-    return;
-  }
-  const GROK_KEY = grokKey;
+  const { grokKey, gptKey, claudeKey, models } = await chrome.storage.local.get([
+    'grokKey',
+    'gptKey',
+    'claudeKey',
+    'models'
+  ]);
 
-  let summary = 'No';
-  try {
-    const r = await fetch(API_URL, {
+  async function callGrok() {
+    const r = await fetch('https://api.x.ai/v1/chat/completions', {
       method: 'POST',
       headers: {
-        'Content-Type':  'application/json',
-        'Authorization': `Bearer ${GROK_KEY}`
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${grokKey}`
       },
       body: JSON.stringify({
-        model:       'grok-3-latest',
+        model: 'grok-3-latest',
         messages: [
           { role: 'system', content: 'You are a binary classifier. Answer “Yes” or “No” ONLY.' },
-          { role: 'user',   content: msg.grokPrompt }
+          { role: 'user', content: msg.prompt }
         ],
-        stream:      false,
+        stream: false,
         temperature: 0
       })
     });
     const j = await r.json();
-    summary = j.choices?.[0]?.message?.content.trim() || 'No';
-  } catch (e) {
-    console.error('Grok call failed', e);
+    return j.choices?.[0]?.message?.content.trim() || 'No';
   }
 
-  // reply back to the tab’s content script
+  async function callGpt() {
+    const r = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${gptKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          { role: 'system', content: 'You are a binary classifier. Answer “Yes” or “No” ONLY.' },
+          { role: 'user', content: msg.prompt }
+        ],
+        temperature: 0
+      })
+    });
+    const j = await r.json();
+    return j.choices?.[0]?.message?.content.trim() || 'No';
+  }
+
+  async function callClaude() {
+    const r = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': claudeKey,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: 'claude-3-sonnet-20240229',
+        max_tokens: 1,
+        system: 'You are a binary classifier. Answer “Yes” or “No” ONLY.',
+        messages: [
+          { role: 'user', content: msg.prompt }
+        ],
+        temperature: 0
+      })
+    });
+    const j = await r.json();
+    return j.content?.[0]?.text?.trim() || 'No';
+  }
+
+  const calls = [];
+  if (models?.includes('grok') && grokKey) calls.push(callGrok());
+  if (models?.includes('gpt') && gptKey) calls.push(callGpt());
+  if (models?.includes('claude') && claudeKey) calls.push(callClaude());
+
+  let summary = 'No';
+  for (const c of calls) {
+    try {
+      summary = await c;
+      if (/^yes$/i.test(summary)) break;
+    } catch (e) {
+      console.error('Model call failed', e);
+    }
+  }
+
   if (sender.tab?.id) {
     chrome.tabs.sendMessage(sender.tab.id, {
-      id:      msg.id,
-      summary: summary
+      id: msg.id,
+      summary
     });
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,8 @@
   ],
   "host_permissions": [
     "https://api.x.ai/*",
+    "https://api.openai.com/*",
+    "https://api.anthropic.com/*",
     "https://x.com/*",
     "https://twitter.com/*"
   ],

--- a/popup.html
+++ b/popup.html
@@ -24,6 +24,8 @@
     <div id="filteringTab" class="tab active">
       <input id="filter" type="text" placeholder="Enter filter phrase…" />
       <input id="grokKey" type="password" placeholder="Enter Grok API key…" />
+      <input id="gptKey" type="password" placeholder="Enter GPT API key…" />
+      <input id="claudeKey" type="password" placeholder="Enter Claude API key…" />
       <div class="models">
         <label><input type="checkbox" id="modelClaude"> Claude</label>
         <label><input type="checkbox" id="modelGpt"> GPT</label>

--- a/popup.js
+++ b/popup.js
@@ -2,6 +2,8 @@
 const btn        = document.getElementById('go');
 const input      = document.getElementById('filter');
 const keyInput   = document.getElementById('grokKey');
+const gptKeyInput    = document.getElementById('gptKey');
+const claudeKeyInput = document.getElementById('claudeKey');
 const status     = document.getElementById('status');
 const filteringTabBtn = document.getElementById('filteringTabBtn');
 const adBlockTabBtn   = document.getElementById('adBlockTabBtn');
@@ -53,15 +55,19 @@ toggleAdsBtn.addEventListener('click', async () => {
 });
 
 async function updateUI() {
-  const { checking, filter, grokKey, filterAds, models } = await chrome.storage.local.get([
+  const { checking, filter, grokKey, gptKey, claudeKey, filterAds, models } = await chrome.storage.local.get([
     'checking',
     'filter',
     'grokKey',
+    'gptKey',
+    'claudeKey',
     'filterAds',
     'models'
   ]);
   input.value = filter || '';
   keyInput.value = grokKey || '';
+  gptKeyInput.value = gptKey || '';
+  claudeKeyInput.value = claudeKey || '';
   btn.textContent = checking ? 'Stop Checking' : 'Check Tweets';
   status.textContent = checking ? 'Checking tweets…' : '';
   toggleAdsBtn.textContent = filterAds ? 'Ad Filtering: On' : 'Ad Filtering: Off';
@@ -80,12 +86,24 @@ btn.addEventListener('click', async () => {
   if (checking) {
     const filter = input.value.trim();
     const grokKey = keyInput.value.trim();
-    if (!filter || !grokKey) {
-      status.textContent = 'Please enter both a filter phrase and API key.';
+    const gptKey = gptKeyInput.value.trim();
+    const claudeKey = claudeKeyInput.value.trim();
+    const models = getSelectedModels();
+    if (!filter ||
+        (models.includes('grok') && !grokKey) ||
+        (models.includes('gpt') && !gptKey) ||
+        (models.includes('claude') && !claudeKey)) {
+      status.textContent = 'Please enter a filter phrase and required API keys.';
       return;
     }
-    const models = getSelectedModels();
-    await chrome.storage.local.set({ filter, grokKey, checking: true, models });
+    await chrome.storage.local.set({
+      filter,
+      grokKey,
+      gptKey,
+      claudeKey,
+      checking: true,
+      models
+    });
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
     await chrome.scripting.executeScript({
       target: { tabId: tab.id },


### PR DESCRIPTION
## Summary
- add API key fields for GPT and Claude
- store/update keys in popup.js
- extend scraper to call background when any model is enabled
- implement GPT and Claude requests in bg.js
- allow API calls to OpenAI and Anthropic domains

## Testing
- `node -c bg.js`
- `node -c popup.js`
- `node -c scraper.js`


------
https://chatgpt.com/codex/tasks/task_e_684c99c869748333b416d8cc0599e5b7