### PR TITLE
Refactor model selection UI

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -2,89 +2,83 @@
 chrome.runtime.onMessage.addListener(async (msg, sender) => {
   if (!msg.prompt) return;
 
-  const { grokKey, gptKey, claudeKey, models } = await chrome.storage.local.get([
-    'grokKey',
-    'gptKey',
-    'claudeKey',
-    'models'
+  const { provider, model, apiKeys } = await chrome.storage.local.get([
+    'provider',
+    'model',
+    'apiKeys'
   ]);
+  const apiKey = apiKeys?.[provider];
 
-  async function callGrok() {
-    const r = await fetch('https://api.x.ai/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${grokKey}`
-      },
-      body: JSON.stringify({
-        model: 'grok-3-latest',
-        messages: [
-          { role: 'system', content: 'You are a binary classifier. Answer “Yes” or “No” ONLY.' },
-          { role: 'user', content: msg.prompt }
-        ],
-        stream: false,
-        temperature: 0
-      })
-    });
-    const j = await r.json();
-    return j.choices?.[0]?.message?.content.trim() || 'No';
+  async function callProvider() {
+    if (!apiKey) return 'No';
+    if (provider === 'xai') {
+      const r = await fetch('https://api.x.ai/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`
+        },
+        body: JSON.stringify({
+          model,
+          messages: [
+            { role: 'system', content: 'You are a binary classifier. Answer “Yes” or “No” ONLY.' },
+            { role: 'user', content: msg.prompt }
+          ],
+          stream: false,
+          temperature: 0
+        })
+      });
+      const j = await r.json();
+      return j.choices?.[0]?.message?.content.trim() || 'No';
+    }
+    if (provider === 'openai') {
+      const r = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`
+        },
+        body: JSON.stringify({
+          model,
+          messages: [
+            { role: 'system', content: 'You are a binary classifier. Answer “Yes” or “No” ONLY.' },
+            { role: 'user', content: msg.prompt }
+          ],
+          temperature: 0
+        })
+      });
+      const j = await r.json();
+      return j.choices?.[0]?.message?.content.trim() || 'No';
+    }
+    if (provider === 'anthropic') {
+      const r = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01'
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 1,
+          system: 'You are a binary classifier. Answer “Yes” or “No” ONLY.',
+          messages: [
+            { role: 'user', content: msg.prompt }
+          ],
+          temperature: 0
+        })
+      });
+      const j = await r.json();
+      return j.content?.[0]?.text?.trim() || 'No';
+    }
+    return 'No';
   }
-
-  async function callGpt() {
-    const r = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${gptKey}`
-      },
-      body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
-        messages: [
-          { role: 'system', content: 'You are a binary classifier. Answer “Yes” or “No” ONLY.' },
-          { role: 'user', content: msg.prompt }
-        ],
-        temperature: 0
-      })
-    });
-    const j = await r.json();
-    return j.choices?.[0]?.message?.content.trim() || 'No';
-  }
-
-  async function callClaude() {
-    const r = await fetch('https://api.anthropic.com/v1/messages', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': claudeKey,
-        'anthropic-version': '2023-06-01'
-      },
-      body: JSON.stringify({
-        model: 'claude-3-sonnet-20240229',
-        max_tokens: 1,
-        system: 'You are a binary classifier. Answer “Yes” or “No” ONLY.',
-        messages: [
-          { role: 'user', content: msg.prompt }
-        ],
-        temperature: 0
-      })
-    });
-    const j = await r.json();
-    return j.content?.[0]?.text?.trim() || 'No';
-  }
-
-  const calls = [];
-  if (models?.includes('grok') && grokKey) calls.push(callGrok());
-  if (models?.includes('gpt') && gptKey) calls.push(callGpt());
-  if (models?.includes('claude') && claudeKey) calls.push(callClaude());
 
   let summary = 'No';
-  for (const c of calls) {
-    try {
-      summary = await c;
-      if (/^yes$/i.test(summary)) break;
-    } catch (e) {
-      console.error('Model call failed', e);
-    }
+  try {
+    summary = await callProvider();
+  } catch (e) {
+    console.error('Model call failed', e);
   }
 
   if (sender.tab?.id) {

--- a/popup.html
+++ b/popup.html
@@ -72,16 +72,6 @@
         display: block;
       }
 
-      .models {
-        display: flex;
-        justify-content: space-between;
-        margin-top: 6px;
-      }
-
-      .models label {
-        flex: 1;
-        font-size: 12px;
-      }
     </style>
   </head>
   <body>
@@ -92,14 +82,13 @@
 
     <div id="filteringTab" class="tab active">
       <input id="filter" type="text" placeholder="Enter filter phrase…" />
-      <input id="grokKey" type="password" placeholder="Enter Grok API key…" />
-      <input id="gptKey" type="password" placeholder="Enter GPT API key…" />
-      <input id="claudeKey" type="password" placeholder="Enter Claude API key…" />
-      <div class="models">
-        <label><input type="checkbox" id="modelClaude" data-model="claude"> Claude</label>
-        <label><input type="checkbox" id="modelGpt" data-model="gpt"> GPT</label>
-        <label><input type="checkbox" id="modelGrok" data-model="grok"> Grok</label>
-      </div>
+      <select id="provider">
+        <option value="openai">OpenAI</option>
+        <option value="anthropic">Anthropic</option>
+        <option value="xai">xAI</option>
+      </select>
+      <select id="model"></select>
+      <input id="apiKey" type="password" placeholder="Enter API key…" />
       <button id="go">Check Tweets</button>
     </div>
 

--- a/scraper.js
+++ b/scraper.js
@@ -3,27 +3,24 @@
   const CHECKED_ATTR = 'data-tc-checked';
   let observer;
   let filter = '';
-  let grokKey = '';
-  let gptKey = '';
-  let claudeKey = '';
+  let provider = 'openai';
+  let model = 'gpt-3.5-turbo';
+  let apiKeys = {};
   let filterAds = true;
-  let models = ['grok'];
 
   async function loadConfig() {
     const cfg = await chrome.storage.local.get([
       'filter',
-      'grokKey',
-      'gptKey',
-      'claudeKey',
-      'filterAds',
-      'models'
+      'provider',
+      'model',
+      'apiKeys',
+      'filterAds'
     ]);
     filter = cfg.filter || '';
-    grokKey = cfg.grokKey || '';
-    gptKey = cfg.gptKey || '';
-    claudeKey = cfg.claudeKey || '';
+    provider = cfg.provider || 'openai';
+    model = cfg.model || 'gpt-3.5-turbo';
+    apiKeys = cfg.apiKeys || {};
     filterAds = cfg.filterAds !== false;
-    models = cfg.models || ['grok'];
   }
 
   async function processCell(cell) {
@@ -44,10 +41,7 @@
       return;
     }
     if (!filter) return;
-    const needGrok  = models.includes('grok') && !grokKey;
-    const needGpt   = models.includes('gpt') && !gptKey;
-    const needClaude= models.includes('claude') && !claudeKey;
-    if (needGrok || needGpt || needClaude) return;
+    if (!apiKeys[provider]) return;
 
     const textNode = cell.querySelector('[data-testid="tweetText"]');
     if (!textNode) return;
@@ -109,11 +103,10 @@ Tweet:
       }
       if (
         'filter' in changes ||
-        'grokKey' in changes ||
-        'gptKey' in changes ||
-        'claudeKey' in changes ||
-        'filterAds' in changes ||
-        'models' in changes
+        'provider' in changes ||
+        'model' in changes ||
+        'apiKeys' in changes ||
+        'filterAds' in changes
       ) {
         loadConfig();
       }


### PR DESCRIPTION
## Summary
- redesign popup to use provider/model dropdowns
- keep one API key field tied to the provider
- refactor popup logic for new selection method
- update background script for single provider call
- simplify scraper configuration to use provider/model

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c9c8929e083339a93f119e6c12064